### PR TITLE
Updated ASA values from newer publication

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -355,7 +355,6 @@ class DSSP(AbstractResiduePropertyMap):
             resname = res.get_resname()
             try:
                 rel_acc = acc / self.residue_max_acc[resname]
-                rel_acc = acc / MAX_ACC[resname]
             except KeyError:
                 # Invalid value for resname
                 rel_acc = 'NA'


### PR DESCRIPTION
Updated, presumably better, ASA values from recent publication. Can be accessed by the "acc_array" key which is set default to the original "Sander" ASA values for backwards compatibility.